### PR TITLE
MPC 2: Electric Boogaloo

### DIFF
--- a/notebooks/MPC with Boolean Contact.ipynb
+++ b/notebooks/MPC with Boolean Contact.ipynb
@@ -1,0 +1,190 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "using QPControl\n",
+    "using RigidBodyDynamics\n",
+    "using RigidBodyDynamics.Contact\n",
+    "using MeshCatMechanisms\n",
+    "using RigidBodySim\n",
+    "using StaticArrays\n",
+    "using BenchmarkTools\n",
+    "using Compat\n",
+    "using Compat.Test\n",
+    "using SimpleQP"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "world = RigidBody{Float64}(\"world\")\n",
+    "mechanism = Mechanism(world; gravity=SVector(0, 0, -9.81))\n",
+    "\n",
+    "frame = CartesianFrame3D(\"core\")\n",
+    "inertia = SpatialInertia(frame, SDiagonal(1., 1, 1), SVector(0., 0, 0), 10.)\n",
+    "core = RigidBody(inertia)\n",
+    "joint = Joint(\"floating_base\", Prismatic(SVector(0., 0, 1)))\n",
+    "attach!(mechanism, world, core, joint)\n",
+    "position_bounds(joint) .= RigidBodyDynamics.Bounds(0, 10)\n",
+    "velocity_bounds(joint) .= RigidBodyDynamics.Bounds(-1000, 1000)\n",
+    "effort_bounds(joint) .= RigidBodyDynamics.Bounds(0, 0)\n",
+    "\n",
+    "frame = CartesianFrame3D(\"foot\")\n",
+    "inertia = SpatialInertia(frame, SDiagonal(0.05, 0.05, 0.05), SVector(0., 0, 0), 1.0)\n",
+    "foot = RigidBody(inertia)\n",
+    "joint = Joint(\"foot_extension\", Prismatic(SVector(0., 0, 1)))\n",
+    "attach!(mechanism, core, foot, joint)\n",
+    "position_bounds(joint) .= RigidBodyDynamics.Bounds(-1., -0.5)\n",
+    "velocity_bounds(joint) .= RigidBodyDynamics.Bounds(-1000, 1000)\n",
+    "effort_bounds(joint) .= RigidBodyDynamics.Bounds(-200, 200)\n",
+    "\n",
+    "\n",
+    "floor = HalfSpace3D(Point3D(default_frame(world), 0., 0, 0), FreeVector3D(default_frame(world), 0., 0, 1))\n",
+    "add_environment_primitive!(mechanism, floor)\n",
+    "contactmodel = SoftContactModel(hunt_crossley_hertz(k = 500e3), ViscoelasticCoulombModel(0.8, 20e3, 100.))\n",
+    "add_contact_point!(foot, Contact.ContactPoint(Point3D(default_frame(foot), 0., 0, 0), contactmodel))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "function initialize!(state::MechanismState)\n",
+    "    set_configuration!(state, [1, -1])\n",
+    "    set_velocity!(state, [0, 0])\n",
+    "    set_additional_state!(state, zeros(Float64, num_additional_states(state)))\n",
+    "    state\n",
+    "end"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mvis = MechanismVisualizer(mechanism, Skeleton(randomize_colors=true))\n",
+    "open(mvis)\n",
+    "copy!(mvis, initialize!(MechanismState(mechanism)))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# create optimizer\n",
+    "using MathOptInterface\n",
+    "using OSQP.MathOptInterfaceOSQP\n",
+    "const MOI = MathOptInterface\n",
+    "using Gurobi\n",
+    "\n",
+    "function defaultoptimizer()\n",
+    "    GurobiOptimizer(OutputFlag=0, TimeLimit=1)\n",
+    "end"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mpc = QPControl.MPCController{QPControl.ContactPoint{4}}(mechanism, defaultoptimizer())\n",
+    "\n",
+    "stages = QPControl.addstages!(mpc, 1, 0.001)\n",
+    "\n",
+    "Q = Diagonal([10, 10, 0.01, 0.01])\n",
+    "xf = vcat(stages[end].q, stages[end].v) - [1, -1, 0, 0]\n",
+    "R = Diagonal([1e-8, 1e-8])\n",
+    "objective = @expression xf' * Q * xf\n",
+    "for stage in stages\n",
+    "    objective = @expression objective + stage.v̇' * R * stage.v̇\n",
+    "\n",
+    "    for body in bodies(mechanism)\n",
+    "        for point in RigidBodyDynamics.contact_points(body)\n",
+    "            position = location(point)\n",
+    "            μ = point.model.friction.μ\n",
+    "            contact = addcontact!(mpc, stage, position, floor, μ)\n",
+    "            contact.maxnormalforce[] = 1e6 # TODO\n",
+    "        end\n",
+    "    end\n",
+    "end\n",
+    "\n",
+    "@objective mpc.qpmodel Minimize objective"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# simulate\n",
+    "state = initialize!(MechanismState(mechanism))\n",
+    "set_configuration!(state, [3.0, -1.0])\n",
+    "Δt = 1 / 500\n",
+    "pcontroller = PeriodicController(similar(velocity(state)), Δt, mpc)\n",
+    "# TODO: add damping\n",
+    "dynamics = Dynamics(mechanism, pcontroller)\n",
+    "problem = ODEProblem(dynamics, state, (0., 10.))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "τ = similar(velocity(state))\n",
+    "@benchmark $mpc($τ, 0.0, $state)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sol = solve(problem, Tsit5(), abs_tol = 1e-8, dt = 1e-6)\n",
+    "@time sol = solve(problem, Tsit5(), abs_tol = 1e-8, dt = 1e-6)\n",
+    "@test sol.retcode == :Success"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#NBSKIP\n",
+    "RigidBodySim.animate(mvis, state, sol)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Julia 0.6.4",
+   "language": "julia",
+   "name": "julia-0.6"
+  },
+  "language_info": {
+   "file_extension": ".jl",
+   "mimetype": "application/julia",
+   "name": "julia",
+   "version": "0.6.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/notebooks/Simple MPC Demo.ipynb
+++ b/notebooks/Simple MPC Demo.ipynb
@@ -1,0 +1,139 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "using RigidBodyDynamics\n",
+    "using QPControl\n",
+    "using SimpleQP\n",
+    "using StaticArrays"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "using OSQP.MathOptInterfaceOSQP\n",
+    "import MathOptInterface\n",
+    "const MOI = MathOptInterface\n",
+    "\n",
+    "function defaultoptimizer()\n",
+    "    optimizer = OSQPOptimizer()\n",
+    "    MOI.set!(optimizer, OSQPSettings.Verbose(), false)\n",
+    "    MOI.set!(optimizer, OSQPSettings.EpsAbs(), 1e-8)\n",
+    "    MOI.set!(optimizer, OSQPSettings.EpsRel(), 1e-8)\n",
+    "    MOI.set!(optimizer, OSQPSettings.MaxIter(), 5000)\n",
+    "    MOI.set!(optimizer, OSQPSettings.AdaptiveRhoInterval(), 25) # required for deterministic behavior\n",
+    "    optimizer\n",
+    "end"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "world = RigidBody{Float64}(\"world\")\n",
+    "mechanism = Mechanism(world, gravity=SVector(0, 0, -9.81))\n",
+    "\n",
+    "frame = CartesianFrame3D(\"core\")\n",
+    "inertia = SpatialInertia(frame, SDiagonal(1., 1, 1), SVector(0., 0, 0), 10.0)\n",
+    "body = RigidBody(inertia)\n",
+    "joint = Joint(\"base_x\", Prismatic(SVector(1., 0, 0)))\n",
+    "effort_bounds(joint) .= RigidBodyDynamics.Bounds(-100, 100)\n",
+    "position_bounds(joint) .= RigidBodyDynamics.Bounds(-100, 100)\n",
+    "attach!(mechanism, world, body, joint)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mpc = MPCController{Void}(mechanism, defaultoptimizer())\n",
+    "stage = addstage!(mpc, 0.001)\n",
+    "\n",
+    "objective = @expression 10 * stage.q[1]^2 + 0.01 * stage.v[1]^2 + 1e-7 * stage.u[1]^2\n",
+    "@objective mpc.qpmodel Minimize objective"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "state = MechanismState(mechanism)\n",
+    "set_configuration!(state, [1.0])\n",
+    "τ = similar(velocity(state));\n",
+    "benchresult = @benchmark $mpc($τ, 0.0, $state)\n",
+    "@test benchresult.allocs == 0\n",
+    "benchresult"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "using BenchmarkTools\n",
+    "\n",
+    "@btime $mpc($τ, 0.0, $state)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "state = MechanismState(mechanism)\n",
+    "set_configuration!(state, [1.0])\n",
+    "ts, qs, vs = simulate(state, 4.0, mpc; Δt=1e-3)\n",
+    "@time simulate(state, 4.0, mpc; Δt=1e-3);"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#NBSKIP\n",
+    "using Plots\n",
+    "plt = plot(ts, first.(qs))\n",
+    "ylims!(plt, (-1, 1))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Julia 0.6.4",
+   "language": "julia",
+   "name": "julia-0.6"
+  },
+  "language_info": {
+   "file_extension": ".jl",
+   "mimetype": "application/julia",
+   "name": "julia",
+   "version": "0.6.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/notebooks/Simple MPC Demo.ipynb
+++ b/notebooks/Simple MPC Demo.ipynb
@@ -9,6 +9,8 @@
     "using RigidBodyDynamics\n",
     "using QPControl\n",
     "using SimpleQP\n",
+    "using Compat.Test\n",
+    "using BenchmarkTools\n",
     "using StaticArrays"
    ]
   },
@@ -76,17 +78,6 @@
     "benchresult = @benchmark $mpc($τ, 0.0, $state)\n",
     "@test benchresult.allocs == 0\n",
     "benchresult"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "using BenchmarkTools\n",
-    "\n",
-    "@btime $mpc($τ, 0.0, $state)"
    ]
   },
   {

--- a/src/QPControl.jl
+++ b/src/QPControl.jl
@@ -50,6 +50,7 @@ include("contacts.jl")
 include("tasks.jl")
 include("exceptions.jl")
 include("lowlevel/momentum.jl")
+include("lowlevel/mpc.jl")
 include("highlevel/standing.jl")
 
 end # module

--- a/src/QPControl.jl
+++ b/src/QPControl.jl
@@ -20,14 +20,15 @@ export
     setdesired!
 
 # Low level
-# Momentum
+export
+    addcontact!
+# Low level: Momentum
 export
     MomentumBasedController,
     addtask!,
-    addcontact!,
     regularize!,
     centroidal_frame
-# MPC
+# Low level: MPC
 export
     MPCController,
     addstage!,

--- a/src/QPControl.jl
+++ b/src/QPControl.jl
@@ -41,6 +41,7 @@ export
 using Compat
 using Compat.LinearAlgebra
 using RigidBodyDynamics
+using RigidBodyDynamics: OneDegreeOfFreedomFixedAxis
 using RigidBodyDynamics.Graphs
 using RigidBodyDynamics.Contact
 using RigidBodyDynamics.PDControl
@@ -53,6 +54,7 @@ import MathOptInterface
 const MOI = MathOptInterface
 const RBD = RigidBodyDynamics
 
+include("utils.jl")
 include("contacts.jl")
 include("tasks.jl")
 include("exceptions.jl")

--- a/src/QPControl.jl
+++ b/src/QPControl.jl
@@ -20,12 +20,18 @@ export
     setdesired!
 
 # Low level
+# Momentum
 export
     MomentumBasedController,
     addtask!,
     addcontact!,
     regularize!,
     centroidal_frame
+# MPC
+export
+    MPCController,
+    addstage!,
+    addstages!
 
 # High level
 export

--- a/src/contacts.jl
+++ b/src/contacts.jl
@@ -38,7 +38,7 @@ struct ContactPoint{N}
     position::Union{Point3D, Parameter{<:Point3D}}
     normal::Union{FreeVector3D, Parameter{<:FreeVector3D}}
     μ::Union{Float64, Parameter{Float64}}
-    toroot::Union{Transform3D, SimpleQP.LazyExpression}
+    toroot::Union{Transform3D, Parametron.LazyExpression}
 
     function ContactPoint{N}(
             position::Union{Point3D, Parameter{<:Point3D}}, normal::Union{FreeVector3D, Parameter{<:FreeVector3D}}, μ::Union{Float64, Parameter{Float64}},

--- a/src/lowlevel/momentum.jl
+++ b/src/lowlevel/momentum.jl
@@ -82,6 +82,7 @@ end
 
 function checkstatus(qpmodel::Parametron.Model)
     ok = terminationstatus(qpmodel) == MOI.Success && primalstatus(qpmodel) == MOI.FeasiblePoint
+    ok = ok || (primalstatus(qpmodel) == MOI.FeasiblePoint && dualstatus(qpmodel) == MOI.FeasiblePoint)
     if !ok
         okish = terminationstatus(qpmodel) == MOI.AlmostSuccess && primalstatus(qpmodel) == MOI.UnknownResultStatus
         if !okish

--- a/src/lowlevel/mpc.jl
+++ b/src/lowlevel/mpc.jl
@@ -302,7 +302,7 @@ function addjointlimit!(controller::MPCController, stage::MPCStage, joint::Joint
     [τ]
 end
 
-function addjointlimits!(controller::MPCController, stage::MPCStage, force_max=10000.0)
+function addjointlimits!(controller::MPCController, stage::MPCStage, force_max=100000.0)
     vcat([addjointlimit!(controller, stage, joint, force_max)
           for joint in tree_joints(controller.mechanism)]...)
 end

--- a/src/lowlevel/mpc.jl
+++ b/src/lowlevel/mpc.jl
@@ -172,7 +172,6 @@ function initialize!(stage::MPCStage, model::Model, state::MechanismState,
     for contact in stage.contacts
         τ_ext = @expression τ_ext + generalized_torque(state, contact, model)
     end
-    @show τ_ext
     @constraint(model, H * (stage.v - v_prev) == Δt * (stage.u - c - τ_ext))
     q̇ = @expression(J_qv * stage.v)
     @constraint(model, q̇ == (1 / Δt) * (stage.q - q_prev))

--- a/src/lowlevel/mpc.jl
+++ b/src/lowlevel/mpc.jl
@@ -15,14 +15,14 @@ struct MPCController{C, O <: MOI.AbstractOptimizer, M <: Mechanism, S <: Mechani
     mechanism::M
     state::S
     dynamicsresult::DynamicsResult{Float64, Float64}
-    qpmodel::SimpleQP.Model{Float64, O}
+    qpmodel::Parametron.Model{Float64, O}
     stages::Vector{MPCStage{C}}
     initialized::Base.RefValue{Bool}
 
     function MPCController{C}(mechanism::Mechanism, optimizer::O) where {C, O <: MOI.AbstractOptimizer}
         state = MechanismState(mechanism)
         dynamicsresult = DynamicsResult(mechanism)
-        qpmodel = SimpleQP.Model(optimizer)
+        qpmodel = Parametron.Model(optimizer)
         stages = Vector{MPCStage{C}}()
         initialized = Ref(false)
         new{C, O, typeof(mechanism), typeof(state)}(mechanism, state, dynamicsresult, qpmodel, stages, initialized)
@@ -397,9 +397,9 @@ function (controller::MPCController)(τ::AbstractVector, t::Number, x::Mechanism
 
     copyto!(controller.state, x)
     solve!(controller.qpmodel)
-    τ .= SimpleQP.value.(controller.qpmodel, first(stages(controller)).u)
+    τ .= Parametron.value.(controller.qpmodel, first(stages(controller)).u)
     if any(isnan, τ)
-        @show SimpleQP.primalstatus(controller.qpmodel)
+        @show Parametron.primalstatus(controller.qpmodel)
         @show t, Vector(x), τ
 
     end

--- a/src/lowlevel/mpc.jl
+++ b/src/lowlevel/mpc.jl
@@ -137,7 +137,6 @@ function initialize_stage!(controller::MPCController, stage_index::Integer)
     τ_ext = SimpleQP.LazyExpression(identity, zeros(AffineFunction{Float64}, num_velocities(state)))
 
     for (body, contact_points) in stage.contacts
-        path_to_root = path(state.mechanism, body, root_body(state.mechanism))
         path_to_body = path(state.mechanism, root_body(state.mechanism), body)
         for (contact_point, surface) in contact_points
             point_in_world = let state = state, point = contact_point
@@ -179,9 +178,9 @@ function initialize_stage!(controller::MPCController, stage_index::Integer)
             @constraint(model, [separation] >= [lb])  # TODO: make scalar
             @constraint(model, [separation] <= [ub])
 
-            J = let state = state, path_to_root = path_to_root
-                Parameter(geometric_jacobian(state, path_to_root), model) do J
-                    geometric_jacobian!(J, state, path_to_root)
+            J = let state = state, path_to_body = path_to_body
+                Parameter(geometric_jacobian(state, path_to_body), model) do J
+                    geometric_jacobian!(J, state, path_to_body)
                 end
             end
             τ_ext = @expression τ_ext + adjoint(angular(J)) * angular(contact_point.wrench_world) + adjoint(linear(J)) * linear(contact_point.wrench_world)

--- a/src/lowlevel/mpc.jl
+++ b/src/lowlevel/mpc.jl
@@ -17,7 +17,7 @@ struct MPCController{C, O <: MOI.AbstractOptimizer, M <: Mechanism, S <: Mechani
     dynamicsresult::DynamicsResult{Float64, Float64}
     qpmodel::SimpleQP.Model{Float64, O}
     stages::Vector{MPCStage{C}}
-    initialized::typeof(Ref(false))
+    initialized::Base.RefValue{Bool}
 
     function MPCController{C}(mechanism::Mechanism, optimizer::O) where {C, O <: MOI.AbstractOptimizer}
         state = MechanismState(mechanism)
@@ -217,7 +217,7 @@ function add_contact_indicators!(controller::MPCController, stage::MPCStage, con
 end
 
 """
-Holds a few useful dynamics paramters which are re-used for each stage in the MPC
+Holds a few useful dynamics parameters which are re-used for each stage in the MPC
 optmization.
 """
 struct DynamicsParams{TH, Tc, TJ}
@@ -268,7 +268,7 @@ function initialize!(controller::MPCController)
         end
     end
     c = let state = controller.state, result = controller.dynamicsresult
-        Parameter(result.dynamicsbias, model) do c
+        Parameter(result.dynamicsbias, model) do _
             dynamics_bias!(result, state)
         end
     end

--- a/src/lowlevel/mpc.jl
+++ b/src/lowlevel/mpc.jl
@@ -1,4 +1,5 @@
 using RigidBodyDynamics: lower, upper, velocity_to_configuration_derivative_jacobian, velocity_to_configuration_derivative_jacobian!
+using Compat: adjoint
 
 struct QuadraticCost{T}
     Q::Matrix{T}
@@ -11,185 +12,236 @@ QuadraticCost{T}(n::Integer) where {T} = QuadraticCost(zeros(T, n, n), zeros(T, 
 all_effort_bounds(m::Mechanism) =
     collect(Base.Iterators.flatten(map(effort_bounds, joints(m))))
 
-struct MPCController{N, O<:MOI.AbstractOptimizer, S<:MechanismState}
+struct MPCStage{N, O<:MOI.AbstractOptimizer, S<:MechanismState}
+    qpmodel::SimpleQP.Model{Float64, O}
     state::S
     result::DynamicsResult{Float64, Float64}
-    horizon::Int
     Δt::Float64
+    configuration::Vector{Variable}
+    velocity::Vector{Variable}
+    input::Vector{Variable}
     contacts::Dict{RigidBody{Float64},
                    Vector{Pair{ContactPoint{N},
                                HalfSpace3D{Float64}}}}
+end
+
+
+mutable struct MPCController{N, O<:MOI.AbstractOptimizer, M<:Mechanism, S<:MechanismState}
+    mechanism::M
     qpmodel::SimpleQP.Model{Float64, O}
-    configurations::Vector{Vector{Variable}}
-    velocities::Vector{Vector{Variable}}
-    inputs::Vector{Vector{Variable}}
+    stages::Vector{MPCStage{N, O, S}}
     running_state_cost::QuadraticCost{Float64}
     running_input_cost::QuadraticCost{Float64}
     terminal_state_cost::QuadraticCost{Float64}
+    objective::SimpleQP.LazyExpression
     initialized::Bool
 
-    function MPCController{N}(mechanism::Mechanism{Float64}, optimizer::O;
-                              horizon::Integer = 1,
-                              Δt = 0.001) where {N, O<:MOI.AbstractOptimizer}
-        state = MechanismState(mechanism)
-        result = DynamicsResult(mechanism)
+    function MPCController{N}(mechanism::Mechanism{Float64}, optimizer::O) where {N, O<:MOI.AbstractOptimizer}
         model = SimpleQP.Model(optimizer)
+        M = typeof(mechanism)
+        S = typeof(MechanismState(mechanism))
+        stages = Vector{MPCStage{N, O, S}}()
+        nq = num_positions(mechanism)
+        nv = num_velocities(mechanism)
+        running_state_cost = QuadraticCost{Float64}(nq + nv)
+        running_input_cost = QuadraticCost{Float64}(nv)
+        terminal_state_cost = QuadraticCost{Float64}(nq + nv)
+        objective = SimpleQP.LazyExpression(identity, zero(QuadraticFunction{Float64}))
 
-        configurations = Vector{Vector{Variable}}()
-        velocities = Vector{Vector{Variable}}()
-        inputs = Vector{Vector{Variable}}()
-        running_state_cost = QuadraticCost{Float64}(num_positions(state) + num_velocities(state))
-        running_input_cost = QuadraticCost{Float64}(num_velocities(state))
-        terminal_state_cost = QuadraticCost{Float64}(num_positions(state) + num_velocities(state))
-
-
-
-        new{N, O, typeof(state)}(
-            state,
-            result,
-            horizon,
-            Δt,
-            Dict{RigidBody{Float64}, Vector{Pair{ContactPoint{N}, HalfSpace3D{Float64}}}}(),
+        new{N, O, M, S}(
+            mechanism,
             model,
-            configurations,
-            velocities,
-            inputs,
+            stages,
             running_state_cost,
             running_input_cost,
             terminal_state_cost,
-            false)
+            objective,
+            false
+            )
     end
 end
 
-function initialize!(controller::MPCController)
-    horizon = controller.horizon
-    Δt = controller.Δt
+horizon(c::MPCController) = length(c.stages)
+stages(c::MPCController) = c.stages
+
+function addstage!(controller::MPCController{N, O, M, S}, Δt::Real = 0.001) where {N, O, M, S}
+    @assert !controller.initialized
     model = controller.qpmodel
-    state = controller.state
-    mechanism = state.mechanism
-    result = controller.result
-    running_state_cost = controller.running_state_cost
-    running_input_cost = controller.running_input_cost
-    terminal_state_cost = controller.terminal_state_cost
-    configurations = controller.configurations
-    velocities = controller.velocities
+    mechanism = controller.mechanism
+    state::S = MechanismState(mechanism)
 
-    objective = SimpleQP.LazyExpression(identity, zero(QuadraticFunction{Float64}))
+    qnext = [Variable(model) for _ in 1:num_positions(state)]
+    vnext = [Variable(model) for _ in 1:num_velocities(state)]
+    u = [Variable(model) for _ in 1:num_velocities(state)]
+    @constraint model u >= lower.(all_effort_bounds(mechanism))
+    @constraint model u <= upper.(all_effort_bounds(mechanism))
 
-    for i in 1:horizon
-        qnext = [Variable(model) for _ in 1:num_positions(state)]
-        push!(controller.configurations, qnext)
-        vnext = [Variable(model) for _ in 1:num_velocities(state)]
-        push!(controller.velocities, vnext)
-        u = [Variable(model) for _ in 1:num_velocities(state)]
-        push!(controller.inputs, u)
-        @constraint model u >= lower.(all_effort_bounds(mechanism))
-        @constraint model u <= upper.(all_effort_bounds(mechanism))
+    contacts = Dict{RigidBody{Float64}, Vector{Pair{ContactPoint{N}, HalfSpace3D{Float64}}}}()
+    result = DynamicsResult(mechanism)
+    stage = MPCStage{N, O, S}(
+        controller.qpmodel, state, result, Δt,
+        qnext, vnext, u, contacts)
+    push!(controller.stages, stage)
+    stage
+end
 
-        H = let state = state
-            Parameter(mass_matrix(state), model) do H
-                mass_matrix!(H, state)
-            end
-        end
-        c = let state = state, result = result
-            Parameter(result.dynamicsbias, model) do c
-                dynamics_bias!(result, state)
-            end
-        end
-        J_qv = let state = state
-            Parameter(velocity_to_configuration_derivative_jacobian(state), model) do J
-                velocity_to_configuration_derivative_jacobian!(J, state)
-            end
-        end
-        τ_ext = SimpleQP.LazyExpression(identity, zeros(AffineFunction{Float64}, num_velocities(state)))
-
-        for (body, contact_points) in controller.contacts
-            path_to_root = path(state.mechanism, body, root_body(state.mechanism))
-            path_to_body = path(state.mechanism, root_body(state.mechanism), body)
-            for (contact_point, surface) in contact_points
-                point_in_world = let state = state, point = contact_point
-                    Parameter(model) do
-                        (transform_to_root(state, point.position.frame) * point.position).v
-                    end
-                end
-                J_point = let state = state,
-                              point = contact_point,
-                              path_to_body = path_to_body,
-                              J_point = point_jacobian(state, path_to_body, transform_to_root(state, point.positio.frame) * point.position)
-                    Parameter(J_point.J, model) do _
-                        p = transform_to_root(state, point.position.frame) * point.position
-                        point_jacobian!(J_point, state, path_to_body, p)
-                    end
-                end
-                linearized_position_in_world = @expression point_in_world + Δt * (J_point * vnext)
-                surface_origin = let surface = surface, mechanism = mechanism
-                    Parameter(model) do
-                        @framecheck surface.point.frame root_frame(mechanism)
-                        surface.point.v
-                    end
-                end
-                surface_normal = let surface = surface, mechanism = mechanism
-                    Parameter(model) do
-                        @framecheck surface.outward_normal.frame root_frame(mechanism)
-                        surface.outward_normal.v
-                    end
-                end
-                separation = @expression(dot(surface_normal,
-                                             linearized_position_in_world) -
-                                         dot(surface_normal, surface_origin))
-                lb = -1e-2
-                ub = let point = contact_point
-                    Parameter(model) do
-                        isenabled(point) ? 1e-2 : 1e9  # TODO: Inf?
-                    end
-                end
-                @constraint(model, [separation] >= [lb])  # TODO: make scalar
-                @constraint(model, [separation] <= [ub])
-
-                J = let state = state, path_to_root = path_to_root
-                    Parameter(geometric_jacobian(state, path_to_root), model) do J
-                        geometric_jacobian!(J, state, path_to_root)
-                    end
-                end
-                τ_ext = @expression τ_ext + transpose(angular(J)) * angular(contact_point.wrench_world) + transpose(linear(J)) * linear(contact_point.wrench_world)
-            end
-        end
-
-        if i == 1
-            q_current = let state = state
-                Parameter(model) do
-                    configuration(state)
-                end
-            end
-            v_current = let state = state
-                Parameter(model) do
-                    velocity(state)
-                end
-            end
-        else
-            q_current = configurations[i - 1]
-            v_current = velocities[i - 1]
-        end
-        @constraint(model, H * (vnext - v_current) == Δt * (u - c - τ_ext))
-        q̇ = @expression(J_qv * vnext)
-        @constraint(model, qnext - q_current == Δt * q̇)
-
-        objective = @expression(objective +
-            objectiveterm(model,
-                          running_state_cost,
-                          vcat(qnext, vnext)))
-        objective = @expression(objective +
-            objectiveterm(model,
-                          running_input_cost,
-                          u))
+function addstages!(c::MPCController, num_stages::Integer, Δt::Real = 0.001)
+    for _ in 1:num_stages
+        addstage!(c, Δt)
     end
+end
+
+function addcontact!(
+        stage::MPCStage{N, O, S},
+        body::RigidBody{Float64},
+        position::Point3D,
+        normal::FreeVector3D,
+        μ::Float64,
+        surface::HalfSpace3D,
+        ) where {N, O, S}
+    contact_point = ContactPoint{N}(position, normal,
+                                    μ, stage.state,
+                                    stage.qpmodel)
+    push!(get!(Vector{Pair{ContactPoint{N}, HalfSpace3D{Float64}}}, stage.contacts, body), (contact_point => surface))
+    # TODO: add objective term
+    contact_point
+end
+
+function initialize_stage!(controller::MPCController, stage_index::Integer)
+    stage = stages(controller)[stage_index]
+
+    state = stage.state
+    mechanism = state.mechanism
+    result = stage.result
+    model = stage.qpmodel
+    Δt = stage.Δt
+    qnext = stage.configuration
+    vnext = stage.velocity
+    u = stage.input
+
+    H = let state = state
+        Parameter(mass_matrix(state), model) do H
+            mass_matrix!(H, state)
+        end
+    end
+    c = let state = state, result = result
+        Parameter(result.dynamicsbias, model) do c
+            dynamics_bias!(result, state)
+        end
+    end
+    J_qv = let state = state
+        Parameter(velocity_to_configuration_derivative_jacobian(state), model) do J
+            velocity_to_configuration_derivative_jacobian!(J, state)
+        end
+    end
+    τ_ext = SimpleQP.LazyExpression(identity, zeros(AffineFunction{Float64}, num_velocities(state)))
+
+    for (body, contact_points) in stage.contacts
+        path_to_root = path(state.mechanism, body, root_body(state.mechanism))
+        path_to_body = path(state.mechanism, root_body(state.mechanism), body)
+        for (contact_point, surface) in contact_points
+            point_in_world = let state = state, point = contact_point
+                Parameter(model) do
+                    (transform_to_root(state, point.position.frame) * point.position).v
+                end
+            end
+            J_point = let state = state,
+                          point = contact_point,
+                          path_to_body = path_to_body,
+                          J_point = point_jacobian(state, path_to_body, transform_to_root(state, point.position.frame) * point.position)
+                Parameter(J_point.J, model) do _
+                    p = transform_to_root(state, point.position.frame) * point.position
+                    point_jacobian!(J_point, state, path_to_body, p)
+                end
+            end
+            linearized_position_in_world = @expression point_in_world + Δt * (J_point * vnext)
+            surface_origin = let surface = surface, mechanism = mechanism
+                Parameter(model) do
+                    @framecheck surface.point.frame root_frame(mechanism)
+                    surface.point.v
+                end
+            end
+            surface_normal = let surface = surface, mechanism = mechanism
+                Parameter(model) do
+                    @framecheck surface.outward_normal.frame root_frame(mechanism)
+                    surface.outward_normal.v
+                end
+            end
+            separation = @expression(dot(surface_normal,
+                                         linearized_position_in_world) -
+                                     dot(surface_normal, surface_origin))
+            lb = -1e-2
+            ub = let point = contact_point
+                Parameter(model) do
+                    isenabled(point) ? 1e-2 : 1e9  # TODO: Inf?
+                end
+            end
+            @constraint(model, [separation] >= [lb])  # TODO: make scalar
+            @constraint(model, [separation] <= [ub])
+
+            J = let state = state, path_to_root = path_to_root
+                Parameter(geometric_jacobian(state, path_to_root), model) do J
+                    geometric_jacobian!(J, state, path_to_root)
+                end
+            end
+            τ_ext = @expression τ_ext + adjoint(angular(J)) * angular(contact_point.wrench_world) + adjoint(linear(J)) * linear(contact_point.wrench_world)
+        end
+    end
+
+    if stage_index == 1
+        q_current = let state = state
+            Parameter(model) do
+                configuration(state)
+            end
+        end
+        v_current = let state = state
+            Parameter(model) do
+                velocity(state)
+            end
+        end
+    else
+        q_current = controller.stages[stage_index - 1].configuration
+        v_current = controller.stages[stage_index - 1].velocity
+    end
+    @constraint(model, H * (vnext - v_current) == Δt * (u - c - τ_ext))
+    q̇ = @expression(J_qv * vnext)
+    @constraint(model, qnext - q_current == Δt * q̇)
+
+    objective = controller.objective
     objective = @expression(objective +
         objectiveterm(model,
-                      terminal_state_cost,
-                      vcat(configurations[end],
-                           velocities[end])))
+                      controller.running_state_cost,
+                      vcat(qnext, vnext)))
+    objective = @expression(objective +
+        objectiveterm(model,
+                      controller.running_input_cost,
+                      u))
+    controller.objective = objective
+end
 
-    @objective(model, Minimize, objective)
+
+function initialize!(controller::MPCController)
+    @assert !controller.initialized
+    model = controller.qpmodel
+    terminal_state_cost = controller.terminal_state_cost
+
+    for i in eachindex(controller.stages)
+        initialize_stage!(controller, i)
+    end
+
+    objective = controller.objective
+    xfinal = vcat(controller.stages[end].configuration,
+                  controller.stages[end].velocity)
+    objective = @expression(objective +
+        objectiveterm(model, terminal_state_cost, xfinal))
+
+    controller.objective = objective
+    setobjective!(controller)
+    controller.initialized = true
+end
+
+function setobjective!(controller::MPCController)
+    @objective(controller.qpmodel, Minimize, controller.objective)
 end
 
 function objectiveterm(model, cost::QuadraticCost, x)
@@ -204,5 +256,36 @@ function objectiveterm(model, cost::QuadraticCost, x)
     end
     x̄ = [Variable(model) for _ in 1:length(cost.x0)]
     @constraint(model, x̄ == x - x0)
-    @expression(x̄' * Q * x̄ + q' * x̄)
+    @expression(x̄' * Q * x̄ + dot(q, x̄))
+end
+
+function (controller::MPCController)(τ::AbstractVector, t::Number, x::Union{<:Vector, <:MechanismState})
+    if !controller.initialized
+        initialize!(controller)
+    end
+    @assert controller.initialized
+
+    # TODO: update controller contact normals
+    for stage in stages(controller)
+        copyto!(stage.state, x)
+    end
+    solve!(controller.qpmodel)
+    τ .= SimpleQP.value.(controller.qpmodel, first(stages(controller)).input)
+end
+
+function addcontact!(
+        controller::MPCController{N},
+        body::RigidBody{Float64},
+        position::Point3D,
+        normal::FreeVector3D,
+        μ::Float64,
+        surface::HalfSpace3D,
+        ) where {N}
+    @assert !controller.initialized
+    contact_point = ContactPoint{N}(position, normal,
+                                    μ, controller.state,
+                                    controller.qpmodel)
+    push!(get!(Vector{Pair{ContactPoint{N}, HalfSpace3D{Float64}}}, controller.contacts, body), (contact_point => surface))
+    # TODO: add objective term
+    contact_point
 end

--- a/src/lowlevel/mpc.jl
+++ b/src/lowlevel/mpc.jl
@@ -1,0 +1,208 @@
+using RigidBodyDynamics: lower, upper, velocity_to_configuration_derivative_jacobian, velocity_to_configuration_derivative_jacobian!
+
+struct QuadraticCost{T}
+    Q::Matrix{T}
+    q::Vector{T}
+    x0::Vector{T}
+end
+
+QuadraticCost{T}(n::Integer) where {T} = QuadraticCost(zeros(T, n, n), zeros(T, n), zeros(T, n))
+
+all_effort_bounds(m::Mechanism) =
+    collect(Base.Iterators.flatten(map(effort_bounds, joints(m))))
+
+struct MPCController{N, O<:MOI.AbstractOptimizer, S<:MechanismState}
+    state::S
+    result::DynamicsResult{Float64, Float64}
+    horizon::Int
+    Δt::Float64
+    contacts::Dict{RigidBody{Float64},
+                   Vector{Pair{ContactPoint{N},
+                               HalfSpace3D{Float64}}}}
+    qpmodel::SimpleQP.Model{Float64, O}
+    configurations::Vector{Vector{Variable}}
+    velocities::Vector{Vector{Variable}}
+    inputs::Vector{Vector{Variable}}
+    running_state_cost::QuadraticCost{Float64}
+    running_input_cost::QuadraticCost{Float64}
+    terminal_state_cost::QuadraticCost{Float64}
+    initialized::Bool
+
+    function MPCController{N}(mechanism::Mechanism{Float64}, optimizer::O;
+                              horizon::Integer = 1,
+                              Δt = 0.001) where {N, O<:MOI.AbstractOptimizer}
+        state = MechanismState(mechanism)
+        result = DynamicsResult(mechanism)
+        model = SimpleQP.Model(optimizer)
+
+        configurations = Vector{Vector{Variable}}()
+        velocities = Vector{Vector{Variable}}()
+        inputs = Vector{Vector{Variable}}()
+        running_state_cost = QuadraticCost{Float64}(num_positions(state) + num_velocities(state))
+        running_input_cost = QuadraticCost{Float64}(num_velocities(state))
+        terminal_state_cost = QuadraticCost{Float64}(num_positions(state) + num_velocities(state))
+
+
+
+        new{N, O, typeof(state)}(
+            state,
+            result,
+            horizon,
+            Δt,
+            Dict{RigidBody{Float64}, Vector{Pair{ContactPoint{N}, HalfSpace3D{Float64}}}}(),
+            model,
+            configurations,
+            velocities,
+            inputs,
+            running_state_cost,
+            running_input_cost,
+            terminal_state_cost,
+            false)
+    end
+end
+
+function initialize!(controller::MPCController)
+    horizon = controller.horizon
+    Δt = controller.Δt
+    model = controller.qpmodel
+    state = controller.state
+    mechanism = state.mechanism
+    result = controller.result
+    running_state_cost = controller.running_state_cost
+    running_input_cost = controller.running_input_cost
+    terminal_state_cost = controller.terminal_state_cost
+    configurations = controller.configurations
+    velocities = controller.velocities
+
+    objective = SimpleQP.LazyExpression(identity, zero(QuadraticFunction{Float64}))
+
+    for i in 1:horizon
+        qnext = [Variable(model) for _ in 1:num_positions(state)]
+        push!(controller.configurations, qnext)
+        vnext = [Variable(model) for _ in 1:num_velocities(state)]
+        push!(controller.velocities, vnext)
+        u = [Variable(model) for _ in 1:num_velocities(state)]
+        push!(controller.inputs, u)
+        @constraint model u >= lower.(all_effort_bounds(mechanism))
+        @constraint model u <= upper.(all_effort_bounds(mechanism))
+
+        H = let state = state
+            Parameter(mass_matrix(state), model) do H
+                mass_matrix!(H, state)
+            end
+        end
+        c = let state = state, result = result
+            Parameter(result.dynamicsbias, model) do c
+                dynamics_bias!(result, state)
+            end
+        end
+        J_qv = let state = state
+            Parameter(velocity_to_configuration_derivative_jacobian(state), model) do J
+                velocity_to_configuration_derivative_jacobian!(J, state)
+            end
+        end
+        τ_ext = SimpleQP.LazyExpression(identity, zeros(AffineFunction{Float64}, num_velocities(state)))
+
+        for (body, contact_points) in controller.contacts
+            path_to_root = path(state.mechanism, body, root_body(state.mechanism))
+            path_to_body = path(state.mechanism, root_body(state.mechanism), body)
+            for (contact_point, surface) in contact_points
+                point_in_world = let state = state, point = contact_point
+                    Parameter(model) do
+                        (transform_to_root(state, point.position.frame) * point.position).v
+                    end
+                end
+                J_point = let state = state,
+                              point = contact_point,
+                              path_to_body = path_to_body,
+                              J_point = point_jacobian(state, path_to_body, transform_to_root(state, point.positio.frame) * point.position)
+                    Parameter(J_point.J, model) do _
+                        p = transform_to_root(state, point.position.frame) * point.position
+                        point_jacobian!(J_point, state, path_to_body, p)
+                    end
+                end
+                linearized_position_in_world = @expression point_in_world + Δt * (J_point * vnext)
+                surface_origin = let surface = surface, mechanism = mechanism
+                    Parameter(model) do
+                        @framecheck surface.point.frame root_frame(mechanism)
+                        surface.point.v
+                    end
+                end
+                surface_normal = let surface = surface, mechanism = mechanism
+                    Parameter(model) do
+                        @framecheck surface.outward_normal.frame root_frame(mechanism)
+                        surface.outward_normal.v
+                    end
+                end
+                separation = @expression(dot(surface_normal,
+                                             linearized_position_in_world) -
+                                         dot(surface_normal, surface_origin))
+                lb = -1e-2
+                ub = let point = contact_point
+                    Parameter(model) do
+                        isenabled(point) ? 1e-2 : 1e9  # TODO: Inf?
+                    end
+                end
+                @constraint(model, [separation] >= [lb])  # TODO: make scalar
+                @constraint(model, [separation] <= [ub])
+
+                J = let state = state, path_to_root = path_to_root
+                    Parameter(geometric_jacobian(state, path_to_root), model) do J
+                        geometric_jacobian!(J, state, path_to_root)
+                    end
+                end
+                τ_ext = @expression τ_ext + transpose(angular(J)) * angular(contact_point.wrench_world) + transpose(linear(J)) * linear(contact_point.wrench_world)
+            end
+        end
+
+        if i == 1
+            q_current = let state = state
+                Parameter(model) do
+                    configuration(state)
+                end
+            end
+            v_current = let state = state
+                Parameter(model) do
+                    velocity(state)
+                end
+            end
+        else
+            q_current = configurations[i - 1]
+            v_current = velocities[i - 1]
+        end
+        @constraint(model, H * (vnext - v_current) == Δt * (u - c - τ_ext))
+        q̇ = @expression(J_qv * vnext)
+        @constraint(model, qnext - q_current == Δt * q̇)
+
+        objective = @expression(objective +
+            objectiveterm(model,
+                          running_state_cost,
+                          vcat(qnext, vnext)))
+        objective = @expression(objective +
+            objectiveterm(model,
+                          running_input_cost,
+                          u))
+    end
+    objective = @expression(objective +
+        objectiveterm(model,
+                      terminal_state_cost,
+                      vcat(configurations[end],
+                           velocities[end])))
+
+    @objective(model, Minimize, objective)
+end
+
+function objectiveterm(model, cost::QuadraticCost, x)
+    x0 = let cost = cost
+        Parameter(() -> cost.x0, model)
+    end
+    Q = let cost = cost
+        Parameter(() -> cost.Q, model)
+    end
+    q = let cost = cost
+        Parameter(() -> cost.q, model)
+    end
+    x̄ = [Variable(model) for _ in 1:length(cost.x0)]
+    @constraint(model, x̄ == x - x0)
+    @expression(x̄' * Q * x̄ + q' * x̄)
+end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,0 +1,10 @@
+"""
+    only(x)
+
+Return the first and only element of `x`. Throws an ArgumentError if
+the length of x is not exactly 1.
+"""
+function only(x)
+    length(x) == 1 || throw(ArgumentError("Expected a collection with exactly one element. Got length(x) = $(length(x)) instead."))
+    first(x)
+end

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -6,3 +6,4 @@ OSQP 0.1.6
 RigidBodySim 0.2.0
 MeshCatMechanisms
 BenchmarkTools
+Rotations

--- a/test/lcp.jl
+++ b/test/lcp.jl
@@ -64,8 +64,8 @@ function simulate_lcp!(state::MechanismState, mpc::MPCController, t_final=1.0)
         push!(vs, velocity(state))
         mpc(τ, t, state)
         # Assume the dynamics behave exactly as modeled in the optimization
-        set_configuration!(state, SimpleQP.value.(mpc.qpmodel, mpc.stages[1].q))
-        set_velocity!(state, SimpleQP.value.(mpc.qpmodel, mpc.stages[1].v))
+        set_configuration!(state, Parametron.value.(mpc.qpmodel, mpc.stages[1].q))
+        set_velocity!(state, Parametron.value.(mpc.qpmodel, mpc.stages[1].v))
     end
     ts, qs, vs
 end

--- a/test/lcp.jl
+++ b/test/lcp.jl
@@ -1,0 +1,127 @@
+using Gurobi
+
+function add_base_joint!(mechanism, label, direction)
+    frame = CartesianFrame3D("base_$(label)_dummy")
+    inertia = SpatialInertia(frame, SDiagonal(0., 0, 0), SVector(0., 0, 0), 0.0)
+    body = RigidBody(inertia)
+    joint = Joint("base_$(label)", Prismatic(direction))
+    effort_bounds(joint) .= RigidBodyDynamics.Bounds(0, 0)
+    attach!(mechanism, last(bodies(mechanism)), body, joint)
+end
+
+function three_dof_point_mass()
+    world = RigidBody{Float64}("world")
+    mechanism = Mechanism(world, gravity=SVector(0, 0, -9.81))
+    add_base_joint!(mechanism, "x", SVector(1., 0, 0))
+    add_base_joint!(mechanism, "y", SVector(0., 1, 0))
+    add_base_joint!(mechanism, "z", SVector(0., 0, 1))
+
+    frame = CartesianFrame3D("core")
+    inertia = SpatialInertia(frame, SDiagonal(0.01, 0.01, 0.01), SVector(0., 0, 0), 1.0)
+    body = RigidBody(inertia)
+    joint = Joint("core_to_base", Fixed{Float64}())
+    attach!(mechanism, last(bodies(mechanism)), body, joint)
+    mechanism
+end
+
+function add_floor!(mechanism, orientation, μ)
+    world = root_body(mechanism)
+    floor = HalfSpace3D(Point3D(default_frame(world), 0., 0, 0), FreeVector3D(default_frame(world), orientation * SVector(0., 0, 1)))
+    add_environment_primitive!(mechanism, floor)
+
+    body = findbody(mechanism, "core")
+    contactmodel = SoftContactModel(hunt_crossley_hertz(k = 500e3), ViscoelasticCoulombModel(μ, 20e3, 100.))
+    add_contact_point!(body, Contact.ContactPoint(Point3D(default_frame(body), 0., 0, 0), contactmodel))
+    floor
+end
+
+function mpc_lcp_feasibility_problem(mechanism, optimizer, floor, Δt)
+    mpc = QPControl.MPCController{QPControl.ContactPoint{8}}(mechanism, optimizer)
+    stage = QPControl.addstage!(mpc, 0.01)
+    for body in bodies(mechanism)
+        for point in RigidBodyDynamics.contact_points(body)
+            position = location(point)
+            μ = point.model.friction.μ
+            contact = addcontact!(mpc, stage, position, floor, μ, QPControl.LCPContact())
+            contact.maxnormalforce[] = 1e6
+        end
+    end
+    mpc
+end
+
+using GLPK
+
+@testset "LCP: sticking and sliding" begin
+    # This test is meant to verify the LCP contact physics by
+    # simulating a point with friction on a variety of sloped planes.
+    # We will test both that for a sufficiently shallow plane, the point
+    # does not slide, and that for a steeper plane it does slide.
+
+    optimizer = GurobiOptimizer(OutputFlag=0, TimeLimit=1)
+
+    @testset "μ = $μ" for μ in [0.25, 0.5, 0.75]
+        @testset "stick = $stick" for stick in [false, true]
+            @testset "axis = $axis" for axis in [RotZ(ϕ) * SVector(1., 0, 0) for ϕ in Compat.range(0, stop=2π-π/4, step=π/4)]
+                θ = atan(μ)
+                if stick
+                    θ -= 0.05
+                else
+                    θ += 0.05
+                end
+                orientation = AngleAxis(θ, axis...)
+                Δt = 0.01
+
+                # Create a mechanism with a 3-DoF, unactuated, floating base.
+                mechanism = three_dof_point_mass()
+                floor = add_floor!(mechanism, orientation, μ)
+
+                # Create an MPC "controller", which we will use as a simple
+                # one-step LCP simulator
+                mpc = mpc_lcp_feasibility_problem(mechanism, optimizer, floor, Δt)
+
+                state = MechanismState(mechanism)
+                # Start off the ground a bit, to be sure we can dissipate
+                # velocity correctly
+                set_configuration!(state, findjoint(mechanism, "base_z"), 0.1)
+
+                # Simulate the system by repeatedly running the MPC controller
+                # and then updating the state based on the expected state
+                # at the end of the first MPC stage.
+                ts = Float64[]
+                qs = Vector{Float64}[]
+                vs = Vector{Float64}[]
+                τ = similar(velocity(state))
+                t_final = 1.0
+                for t in 0:Δt:t_final
+                    push!(ts, t)
+                    push!(qs, configuration(state))
+                    push!(vs, velocity(state))
+                    mpc(τ, t, state)
+                    # Assume the dynamics behave exactly as modeled in the optimization
+                    set_configuration!(state, SimpleQP.value.(mpc.qpmodel, mpc.stages[1].q))
+                    set_velocity!(state, SimpleQP.value.(mpc.qpmodel, mpc.stages[1].v))
+                end
+
+                # The point should be on the floor
+                @test floor.outward_normal.v' * qs[end] ≈ floor.outward_normal.v' * floor.point.v atol=1e-4
+
+                if stick
+                    # The point should have dropped straight down and stopped when it
+                    # hit the floor, without sliding
+                    @test qs[end] ≈ [0, 0, 0] atol=1e-3
+                    @test vs[end] ≈ [0, 0, 0] atol=1e-3
+                else
+                    # The point should be sliding downhill
+                    expected_direction = orientation * RotZ(-π/2) * axis
+                    @test dot(normalize(vs[end]), expected_direction) ≈ 1
+
+                    # The point should not have moved perpendicular to the slope
+                    @test dot(qs[end], axis) ≈ 0 atol=1e-2
+                end
+            end
+        end
+    end
+end
+
+
+

--- a/test/lcp.jl
+++ b/test/lcp.jl
@@ -6,7 +6,8 @@ function add_base_joint!(mechanism, label, direction)
     body = RigidBody(inertia)
     joint = Joint("base_$(label)", Prismatic(direction))
     effort_bounds(joint) .= RigidBodyDynamics.Bounds(0, 0)
-    attach!(mechanism, last(bodies(mechanism)), body, joint)
+    parent = last(bodies(mechanism))
+    attach!(mechanism, parent, body, joint)
 end
 
 function three_dof_point_mass()
@@ -20,7 +21,8 @@ function three_dof_point_mass()
     inertia = SpatialInertia(frame, SDiagonal(0.01, 0.01, 0.01), SVector(0., 0, 0), 1.0)
     body = RigidBody(inertia)
     joint = Joint("core_to_base", Fixed{Float64}())
-    attach!(mechanism, last(bodies(mechanism)), body, joint)
+    parent = last(bodies(mechanism))
+    attach!(mechanism, parent, body, joint)
     mechanism
 end
 

--- a/test/lcp.jl
+++ b/test/lcp.jl
@@ -24,14 +24,13 @@ function three_dof_point_mass()
     mechanism
 end
 
-function add_floor!(mechanism, orientation, μ)
+function add_floor!(mechanism, orientation, μ, contacting_body)
     world = root_body(mechanism)
     floor = HalfSpace3D(Point3D(default_frame(world), 0., 0, 0), FreeVector3D(default_frame(world), orientation * SVector(0., 0, 1)))
     add_environment_primitive!(mechanism, floor)
 
-    body = findbody(mechanism, "core")
     contactmodel = SoftContactModel(hunt_crossley_hertz(k = 500e3), ViscoelasticCoulombModel(μ, 20e3, 100.))
-    add_contact_point!(body, Contact.ContactPoint(Point3D(default_frame(body), 0., 0, 0), contactmodel))
+    add_contact_point!(contacting_body, Contact.ContactPoint(Point3D(default_frame(contacting_body), 0., 0, 0), contactmodel))
     floor
 end
 
@@ -49,7 +48,25 @@ function mpc_lcp_feasibility_problem(mechanism, optimizer, floor, Δt)
     mpc
 end
 
-using GLPK
+function simulate_lcp!(state::MechanismState, mpc::MPCController, t_final=1.0)
+    # Simulate the system by repeatedly running the MPC controller
+    # and then updating the state based on the expected state
+    # at the end of the first MPC stage.
+    ts = Float64[]
+    qs = Vector{Float64}[]
+    vs = Vector{Float64}[]
+    τ = similar(velocity(state))
+    for t in 0 : (mpc.stages[1].Δt) : t_final
+        push!(ts, t)
+        push!(qs, configuration(state))
+        push!(vs, velocity(state))
+        mpc(τ, t, state)
+        # Assume the dynamics behave exactly as modeled in the optimization
+        set_configuration!(state, SimpleQP.value.(mpc.qpmodel, mpc.stages[1].q))
+        set_velocity!(state, SimpleQP.value.(mpc.qpmodel, mpc.stages[1].v))
+    end
+    ts, qs, vs
+end
 
 @testset "LCP: sticking and sliding" begin
     # This test is meant to verify the LCP contact physics by
@@ -73,7 +90,7 @@ using GLPK
 
                 # Create a mechanism with a 3-DoF, unactuated, floating base.
                 mechanism = three_dof_point_mass()
-                floor = add_floor!(mechanism, orientation, μ)
+                floor = add_floor!(mechanism, orientation, μ, findbody(mechanism, "core"))
 
                 # Create an MPC "controller", which we will use as a simple
                 # one-step LCP simulator
@@ -84,23 +101,7 @@ using GLPK
                 # velocity correctly
                 set_configuration!(state, findjoint(mechanism, "base_z"), 0.1)
 
-                # Simulate the system by repeatedly running the MPC controller
-                # and then updating the state based on the expected state
-                # at the end of the first MPC stage.
-                ts = Float64[]
-                qs = Vector{Float64}[]
-                vs = Vector{Float64}[]
-                τ = similar(velocity(state))
-                t_final = 1.0
-                for t in 0:Δt:t_final
-                    push!(ts, t)
-                    push!(qs, configuration(state))
-                    push!(vs, velocity(state))
-                    mpc(τ, t, state)
-                    # Assume the dynamics behave exactly as modeled in the optimization
-                    set_configuration!(state, SimpleQP.value.(mpc.qpmodel, mpc.stages[1].q))
-                    set_velocity!(state, SimpleQP.value.(mpc.qpmodel, mpc.stages[1].v))
-                end
+                ts, qs, vs = simulate_lcp!(state, mpc)
 
                 # The point should be on the floor
                 @test floor.outward_normal.v' * qs[end] ≈ floor.outward_normal.v' * floor.point.v atol=1e-4
@@ -124,4 +125,110 @@ using GLPK
 end
 
 
+"""
+A two-link mechanism consisting of a body and a foot, both moving along the
+world Z axis.
+"""
+function hopper()
+    world = RigidBody{Float64}("world")
+    mechanism = Mechanism(world; gravity=SVector(0, 0, -9.81))
 
+    frame = CartesianFrame3D("core")
+    inertia = SpatialInertia(frame, SDiagonal(1., 1, 1), SVector(0., 0, 0), 10.)
+    core = RigidBody(inertia)
+    joint = Joint("floating_base", Prismatic(SVector(0., 0, 1)))
+    attach!(mechanism, world, core, joint)
+    position_bounds(joint) .= RigidBodyDynamics.Bounds(0, 2)
+    velocity_bounds(joint) .= RigidBodyDynamics.Bounds(-100, 100)
+    effort_bounds(joint) .= RigidBodyDynamics.Bounds(0, 0)
+
+    frame = CartesianFrame3D("foot")
+    inertia = SpatialInertia(frame, SDiagonal(0.05, 0.05, 0.05), SVector(0., 0, 0), 1.0)
+    foot = RigidBody(inertia)
+    joint = Joint("foot_extension", Prismatic(SVector(0., 0, 1)))
+    attach!(mechanism, core, foot, joint)
+    position_bounds(joint) .= RigidBodyDynamics.Bounds(-1., -0.5)
+    velocity_bounds(joint) .= RigidBodyDynamics.Bounds(-100, 100)
+    effort_bounds(joint) .= RigidBodyDynamics.Bounds(0, 0)
+    mechanism
+end
+
+@testset "LCP with joint limits" begin
+    optimizer = GurobiOptimizer(OutputFlag=0, TimeLimit=1)
+    mechanism = hopper()
+    floor = add_floor!(mechanism, RotX(0.0), 1.0, findbody(mechanism, "foot"))
+    # Create an MPC "controller", which we will use as a simple
+    # one-step LCP simulator
+    Δt = 0.01
+    mpc = mpc_lcp_feasibility_problem(mechanism, optimizer, floor, Δt)
+
+    state = MechanismState(mechanism)
+
+    # We're going to start the hopper slightly off the ground, with both
+    # bodies moving upward. The expected behavior is:
+    # 1. Both bodies move up together, with v1 decelerating at 9.81m/s2 and
+    #    v2 constant at 0
+    # 2. The upper link hits its position limit at q1 = 2.0 and immediately
+    #    stops.
+    # 3. The lower link continues at the same velocity in world frame, while
+    #    the upper link starts to fall
+    # 4. The joint from upper to lower link hits its position limit at q2 = -0.5,
+    #    causing v2 to drop to 0 immediately. v1 increases slightly due to the impact
+    # 5. Both bodies fall together, with q2 fixed at -0.5 and v2 fixed at 0
+    # 6. The foot hits the ground when q1 = 0.5 and q2 = -0.5, at which point
+    #    v1 also drops to 0 immediately
+    # 7. Both bodies remain at rest at q1 = 0.5, q2 = -0.5
+
+    set_configuration!(state, [1.5, -1.0])
+    set_velocity!(state, [5.0, 0.0])
+
+    ts, qs, vs = simulate_lcp!(state, mpc)
+    @test qs[1] ≈ [1.5, -1.0]
+    @test vs[1] ≈ [5.0, 0.0]
+    @test ts[1] ≈ 0
+
+    # 1. Both bodies move up together, with v1 decelerating at 9.81m/s2 and
+    #    v2 constant at 0
+    #
+    # q1(t) = 1.5 + 5.0 t - 1/2 * 9.81 * t^2 = 2.0
+    # So the first collision occurs at t = 0.11239194149021249
+    for i in 1:12
+        t = Δt * (i - 1)
+        @test ts[i] ≈ t
+        @test vs[i] ≈ [5.0 - 9.81 * t, 0.0]
+        @test qs[i] ≈ [1.5 + 5.0 * t - 1/2 * 9.81 * t^2, -1.0] rtol=1e-2
+    end
+
+    # 2. The upper link hits its position limit at q1 = 2.0 and immediately
+    #    stops.
+    @test qs[13][1] ≈ 2.0
+    @test vs[14][1] ≈ 0 atol=1e-4
+
+    # 3. The lower link continues at the same velocity in world frame, while
+    #    the upper link starts to fall
+    for i in 15:25
+        @test vs[i] ≈ [-9.81 * Δt * (i - 14), vs[14][2]]
+    end
+
+    # 4. The joint from upper to lower link hits its position limit at q2 = -0.5,
+    #    causing v2 to drop to 0 immediately. v1 increases slightly due to the impact
+    # 5. Both bodies fall together, with q2 fixed at -0.5 and v2 fixed at 0
+    for i in 27:length(ts)
+        @test qs[i][2] ≈ -0.5
+        @test vs[i][2] ≈ 0 atol=1e-4
+    end
+
+    # 6. The foot hits the ground when q1 = 0.5 and q2 = -0.5, at which point
+    #    v1 also drops to 0 immediately
+    #
+    # this takes about 0.45 seconds after the previous impact
+    @test qs[27 + 44] ≈ [0.531, -0.5] atol=1e-3
+    @test vs[27 + 44] ≈ [-5.253, 0.0] atol=1e-3
+    @test qs[27 + 45] ≈ [0.5, -0.5] atol=1e-4
+
+    # 7. Both bodies remain at rest at q1 = 0.5, q2 = -0.5
+    for i in 73:length(ts)
+        @test qs[i] ≈ [0.5, -0.5] atol=1e-4
+        @test vs[i] ≈ [0, 0] atol=1e-4
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -44,5 +44,6 @@ end
 include("tasks.jl")
 include("notebooks.jl")
 include("controller.jl")
+include("lcp.jl")
 
 end # module


### PR DESCRIPTION
Still a bit of a work-in-progress, but much improved from the previous PR. This is essentially a total rewrite of the MPC approach, and it should be much nicer. 

The most recent improvement is the addition of a Stewart&Trinkle-style LCP contact model (position-based). I added a test that uses a 1-step MPC controller as a 1-step simulator to test that model for a point sticking and sliding on a slope. That test currently requires Gurobi, but it should be possible to run with GLPK (since there's no objective function). 

